### PR TITLE
fixing https://github.com/thiagolocatelli/parse4j/issues/26

### DIFF
--- a/src/main/java/org/parse4j/ParseQuery.java
+++ b/src/main/java/org/parse4j/ParseQuery.java
@@ -325,7 +325,7 @@ public class ParseQuery<T extends ParseObject> {
 	}
 	
 	
-	JSONObject toREST() {
+	public JSONObject toREST() {
 		JSONObject params = new JSONObject();
 		try {
 			params.put("className", this.className);

--- a/src/main/java/org/parse4j/util/ParseEncoder.java
+++ b/src/main/java/org/parse4j/util/ParseEncoder.java
@@ -120,6 +120,10 @@ public class ParseEncoder {
 			return output;	
 		}
 		
+		if(value instanceof ParseQuery){
+			return ((ParseQuery) value).toREST();
+		}
+		
 		if(Parse.isValidType(value)) {
 			return value;	
 		}

--- a/src/test/java/org/parse4j/ParseRelationTestCase.java
+++ b/src/test/java/org/parse4j/ParseRelationTestCase.java
@@ -1,6 +1,8 @@
 package org.parse4j;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -60,6 +62,19 @@ public class ParseRelationTestCase extends Parse4JTestCase {
 	}
 
 	
+
+	@Test
+	public void relation4() throws ParseException {
+		ParseQuery<ParseObject> query = ParseQuery.getQuery("Post");
+		query.whereEqualTo("title", "Post Number 20");
+		
+		ParseQuery<ParseObject> commentsQuery = ParseQuery.getQuery("Comment");
+		commentsQuery.whereMatchesQuery("parent", query);
+		List<ParseObject> find = commentsQuery.find();
+		
+		assertNotNull(find);
+		assertTrue(find.size()>1);
+	}	
 	@Test
 	public void relation() throws ParseException {	
 
@@ -105,7 +120,7 @@ public class ParseRelationTestCase extends Parse4JTestCase {
 			System.out.println(po.getDate("start"));
 		}
 	}
-	
+
 	@Test
 	public void relation2() throws ParseException {	
 


### PR DESCRIPTION
Hello man, i fixed the  "whereMatchesQuery" Parse method. I made two changes:

1. I changed the visibility to the method toRest() to public in ParseQuery.java
2. In ParseEncoder.java I'm checking if argument type is of type ParseQuery 

I also made a test case.

Please review the changes.
 Thanks in advance