### PR TITLE
Disable checks for ParseUser on login

### DIFF
--- a/src/main/java/org/parse4j/ParseUser.java
+++ b/src/main/java/org/parse4j/ParseUser.java
@@ -170,7 +170,7 @@ public class ParseUser extends ParseObject {
 				jsonResponse.remove(ParseConstants.FIELD_CREATED_AT);
 				jsonResponse.remove(ParseConstants.FIELD_UPDATED_AT);
 				jsonResponse.remove(ParseConstants.FIELD_SESSION_TOKEN);
-				parseUser.setData(jsonResponse);
+				parseUser.setData(jsonResponse,true);
 				return parseUser;
 				
 			}catch (JSONException e) {


### PR DESCRIPTION
Error being cause because it does a check on the ParseUser after login for unsaved ParseFiles (which they should be anyways)
