### PR TITLE
Allow getParseObject() to return type variables that extend ParseObject

### DIFF
--- a/src/main/java/org/parse4j/ParseObject.java
+++ b/src/main/java/org/parse4j/ParseObject.java
@@ -234,7 +234,8 @@ public class ParseObject {
 		return returnValue;
 	}
 	
-	public ParseObject getParseObject(String key) {
+    @SuppressWarnings("unchecked")
+    public <T extends ParseObject> T getParseObject(String key) {
 		if (!this.data.containsKey(key)) {
 			return null;
 		}
@@ -243,7 +244,7 @@ public class ParseObject {
 			LOGGER.error("Called getParseObject(\"{}\") but the value is a {}", key, value.getClass());
 			return null;
 		}
-		return (ParseObject) value;
+        return (T) value;
 	}
 	
 	public Object get(String key) {


### PR DESCRIPTION
I am using my custom classes extending ParseObject and I couldn't use this method. This should be the standard return for this method as it is for others alike.